### PR TITLE
removeUnusedParamFromAdCall

### DIFF
--- a/AMoAdCocos2dxModuleDemo/proj.ios_mac/AMoAdSdk/AMoAdView.h
+++ b/AMoAdCocos2dxModuleDemo/proj.ios_mac/AMoAdSdk/AMoAdView.h
@@ -74,9 +74,6 @@ typedef NS_ENUM(NSInteger, AMoAdClickTransition) {
 - (void)AMoAdViewWillClickBack:(AMoAdView *)amoadView;
 /// 広告がクリックされた後、戻ってきた
 - (void)AMoAdViewDidClickBack:(AMoAdView *)amoadView;
-
-// 使用されていないメソッド（互換性のために残している）
-- (void)AMoAdView:(AMoAdView *)amoadView didFailToReceiveAdWithError:(NSError *)error DEPRECATED_ATTRIBUTE;
 @end
 
 


### PR DESCRIPTION
不使用のパラメータをad callから削除しました。
