### PR TITLE
AndroidStudioDemoBugFix

### DIFF
--- a/AMoAdCocos2dxModuleDemo/proj.android-studio/app/jni/Android.mk
+++ b/AMoAdCocos2dxModuleDemo/proj.android-studio/app/jni/Android.mk
@@ -11,15 +11,15 @@ LOCAL_MODULE := cocos2dcpp_shared
 LOCAL_MODULE_FILENAME := libcocos2dcpp
 
 LOCAL_SRC_FILES := hellocpp/main.cpp \
-                   ../../Classes/AMoAdCocos2dxModule.cpp \
-                   ../../Classes/AMoAdNativeCocos2dxModule.cpp \
-                   ../../Classes/AppDelegate.cpp \
-                   ../../Classes/MainScene.cpp \
-                   ../../Classes/FormScene.cpp \
-                   ../../Classes/DisplayScene.cpp \
-                   ../../Classes/InterstitialScene.cpp \
-                   ../../Classes/NativeHtmlScene.cpp \
-                   ../../Classes/Bundle.cpp
+                   ../../../Classes/AMoAdCocos2dxModule.cpp \
+                   ../../../Classes/AMoAdNativeCocos2dxModule.cpp \
+                   ../../../Classes/AppDelegate.cpp \
+                   ../../../Classes/MainScene.cpp \
+                   ../../../Classes/FormScene.cpp \
+                   ../../../Classes/DisplayScene.cpp \
+                   ../../../Classes/InterstitialScene.cpp \
+                   ../../../Classes/NativeHtmlScene.cpp \
+                   ../../../Classes/Bundle.cpp
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../../Classes
 


### PR DESCRIPTION
@hashikell @kinjo1506 
- Android Studio版のデモアプリにコンパイルが通らない不具合があり、対応します。
```
make: Entering directory `/Users/xxx/Git/amoad-cocos2dx-module/AMoAdCocos2dxModuleDemo/proj.android-studio/app'
make: *** No rule to make target `jni/../../Classes/AMoAdCocos2dxModule.cpp', needed by `obj/local/armeabi/objs-debug/cocos2dcpp_shared/__/__/Classes/AMoAdCocos2dxModule.o'.  Stop.
make: *** Waiting for unfinished jobs....
[armeabi] Compile++ thumb: cocos2dcpp_shared <= main.cpp
make: Leaving directory `/Users/xxx/Git/amoad-cocos2dx-module/AMoAdCocos2dxModuleDemo/proj.android-studio/app'
Error running command, return code: 2.

```
動作確認ずみです。マージします。